### PR TITLE
Add janitor/ttl feature

### DIFF
--- a/src/AutoCrane.Tests/DurationParserTests.cs
+++ b/src/AutoCrane.Tests/DurationParserTests.cs
@@ -1,0 +1,36 @@
+﻿using AutoCrane.Services;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace AutoCrane.Tests
+{
+    [TestClass]
+    public class DurationParserTests
+    {
+
+        [DataRow("1d", 60*60*24)]
+        [DataRow("3d", 60*60*24*3)]
+        [DataRow("3h", 60*60*3)]
+        [DataRow("3m", 60*3)]
+        [DataRow("3s", 3)]
+        [DataRow("3ms", null)]
+        [DataRow("", null)]
+        [DataRow("1", null)]
+        [DataTestMethod]
+        public void TestDurations(string str, int? seconds)
+        {
+            var x = new DurationParser();
+            
+            var result = x.Parse(str);
+
+            if (seconds == null)
+            {
+                Assert.IsNull(result);
+            }
+            else
+            {
+                Assert.AreEqual(TimeSpan.FromSeconds((double)seconds!), result);
+            }
+        }
+    }
+}

--- a/src/AutoCrane/DependencyInjection.cs
+++ b/src/AutoCrane/DependencyInjection.cs
@@ -59,6 +59,8 @@ namespace AutoCrane
             services.AddSingleton<ICredentialProvider, CredentialProviderForAzureManagedIdentity>();
             services.AddSingleton<ICredentialProvider, CredentialProviderForAzureKeyVault>();
             services.AddSingleton<ICredentialProvider, CredentialProviderForAzureDevOps>();
+            services.AddSingleton<IDurationParser, DurationParser>();
+            services.AddSingleton<IExpiredObjectDeleter, ExpiredObjectDeleter>();
 
             services.AddSingleton<CredentialProviderForAzureManagedIdentity>();
             services.AddSingleton<KubernetesClient>();

--- a/src/AutoCrane/Interfaces/IDurationParser.cs
+++ b/src/AutoCrane/Interfaces/IDurationParser.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+
+namespace AutoCrane.Interfaces
+{
+    public interface IDurationParser
+    {
+        TimeSpan? Parse(string duration);
+    }
+}

--- a/src/AutoCrane/Interfaces/IExpiredObjectDeleter.cs
+++ b/src/AutoCrane/Interfaces/IExpiredObjectDeleter.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace AutoCrane.Interfaces
+{
+    public interface IExpiredObjectDeleter
+    {
+        Task DeleteAsync(string ns, CancellationToken token);
+    }
+}

--- a/src/AutoCrane/Services/DurationParser.cs
+++ b/src/AutoCrane/Services/DurationParser.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using AutoCrane.Interfaces;
+
+namespace AutoCrane.Services
+{
+    internal class DurationParser : IDurationParser
+    {
+        public DurationParser()
+        {
+        }
+
+        public TimeSpan? Parse(string duration)
+        {
+            duration = duration.Trim();
+            if (duration.Length < 2)
+            {
+                return null;
+            }
+
+            var unit = duration[duration.Length - 1];
+            TimeSpan multiplier;
+            switch (unit)
+            {
+                case 'd':
+                    multiplier = TimeSpan.FromDays(1);
+                    break;
+                case 'h':
+                    multiplier = TimeSpan.FromHours(1);
+                    break;
+                case 'm':
+                    multiplier = TimeSpan.FromMinutes(1);
+                    break;
+                case 's':
+                    multiplier = TimeSpan.FromSeconds(1);
+                    break;
+                default:
+                    return null;
+            }
+
+            if (int.TryParse(duration.AsSpan(0, duration.Length - 1), out var amount))
+            {
+                return multiplier * amount;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/AutoCrane/Services/ExpiredObjectDeleter.cs
+++ b/src/AutoCrane/Services/ExpiredObjectDeleter.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using AutoCrane.Interfaces;
+
+namespace AutoCrane.Services
+{
+    internal sealed class ExpiredObjectDeleter : IExpiredObjectDeleter
+    {
+        private readonly IClock clock;
+        private readonly KubernetesClient client;
+
+        public ExpiredObjectDeleter(IClock clock, KubernetesClient client)
+        {
+            this.clock = clock;
+            this.client = client;
+        }
+
+        public Task DeleteAsync(string ns, CancellationToken token)
+        {
+            return this.client.DeleteExpiredObjects(ns, this.clock.Get(), token);
+        }
+    }
+}


### PR DESCRIPTION
This janitor/ttl feature lets you set an annotation on deployments or services to have them cleaned up after a certain amount of time. The amount of time is calculated from the creationDate of a resource. the TTL value specified similar to golang duration values.

Sample:
```
          apiVersion: apps/v1
          kind: Deployment
          metadata:
            name: xyz
            namespace: abc
            annotations:
              janitor/ttl: "4h"
```

Autocrane will delete the above deployment after 4 hours. You'll need to give the orchestrator permissions:

```
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: autocrane-deployment-reader-writer
  labels:
    app.kubernetes.io/name: autocrane
    app.kubernetes.io/part-of: autocrane
rules:
- apiGroups: ["apps"]
  resources: ["deployments"]
  verbs: ["list", "delete"]
---
kind: Role
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: autocrane-service-reader-writer
  labels:
    app.kubernetes.io/name: autocrane
    app.kubernetes.io/part-of: autocrane
rules:
- apiGroups: [""]
  resources: ["services"]
  verbs: ["list", "delete"]
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: autocrane-deployment-reader-writer-binding-autocrane
  labels:
    app.kubernetes.io/name: autocrane
    app.kubernetes.io/part-of: autocrane
subjects:
- kind: ServiceAccount
  name: autocrane
roleRef:
  kind: Role
  name: autocrane-deployment-reader-writer
  apiGroup: rbac.authorization.k8s.io
---
kind: RoleBinding
apiVersion: rbac.authorization.k8s.io/v1
metadata:
  name: autocrane-service-reader-writer-binding-autocrane
  labels:
    app.kubernetes.io/name: autocrane
    app.kubernetes.io/part-of: autocrane
subjects:
- kind: ServiceAccount
  name: autocrane
roleRef:
  kind: Role
  name: autocrane-service-reader-writer
  apiGroup: rbac.authorization.k8s.io
```